### PR TITLE
Party Page Conversion

### DIFF
--- a/Project1VS/force-app/main/default/aura/party/party.cmp
+++ b/Project1VS/force-app/main/default/aura/party/party.cmp
@@ -1,0 +1,68 @@
+<aura:component controller="partyController" implements="force:appHostable,flexipage:availableForAllPageTypes,forceCommunity:availableForAllPageTypes" access="global" >
+    <aura:attribute name="parties" type="Party__c[]"/>
+    <aura:handler name="init" value="{!this}" action="{!c.fillParties}"/>
+    <aura:attribute name="currentParty" type="Party__c"/>
+    <aura:attribute name="characters" type="Character__c[]"/>
+    <aura:attribute name="campaign" type="DnDCampaign__c"/>
+    <div class="slds-page-header">                                 
+        <h1 class="slds-page-header__title">Party List</h1>                                  
+    </div>
+    <table class="slds-table slds-table_bordered slds-table_col-bordered">
+        <thead><tr><th>Party Name</th></tr></thead>
+        <tbody>           
+            <aura:iteration items="{!v.parties}" var="party">
+                <tr>
+                    <td>
+                        <lightning:button variant="base" label="{!party.Name}" onclick="{!c.displayParty}" value="{!party}"/>
+                    </td>
+                </tr>
+            </aura:iteration>            
+        </tbody>
+    </table>
+    <aura:if isTrue="{!v.currentParty}">
+        <div class="slds-page-header">                                 
+            <h1 class="slds-page-header__title">Party Info: {!v.currentParty.Name}</h1>                                  
+        </div>
+        <table class="slds-table slds-table_bordered slds-table_col-bordered">
+            <thead>
+                <!--tr><th>Party Info</th></tr-->
+                <tr>
+                    <th>Players</th>
+                    <th>Characters</th>
+                </tr>
+            </thead>
+            <tbody>           
+                <aura:iteration items="{!v.characters}" var="character">
+                    <tr>
+                        <td class="slds-size_1-of-2">
+                            <a href="{!'/' + character.User__c}">{!character.User__r.Name}</a>
+                            <!--lightning:button variant="base" label="{!character.User__r.Name}"/-->
+                        </td>
+                        <td class="slds-size_1-of-2">
+                            <a href="{!'/' + character.Id}">{!character.Name}</a>
+                            <!--lightning:button variant="base" label="{!character.Name}"/-->
+                        </td>
+                        
+                    </tr>
+                </aura:iteration>            
+            </tbody>
+        </table>
+    	<table class="slds-table slds-table_bordered slds-table_col-bordered">
+            <thead>
+                <tr>
+                    <th>Dungeon Master</th>
+                    <th>Campaign</th>
+                </tr>
+            </thead>
+            <tbody>           
+                <tr>
+                    <td class="slds-size_1-of-2">
+                        <a href="{!'/' + v.campaign.Dungeon_Master__c}">{!v.campaign.Dungeon_Master__r.Name}</a>
+                        <!--lightning:button variant="base" label="{!v.campaign.Dungeon_Master__r.Name}"/-->
+                    </td>
+                    <td class="slds-size_1-of-2">{!v.campaign.Campaign_Name__c}</td>                  
+                </tr>          
+            </tbody>
+        </table>
+    </aura:if>
+</aura:component>

--- a/Project1VS/force-app/main/default/aura/party/party.cmp-meta.xml
+++ b/Project1VS/force-app/main/default/aura/party/party.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <description>Displays a list of the current user&apos;s visible parties. Clicking a party in that list displays player, character, campaign, and dungeon master information.</description>
+</AuraDefinitionBundle>

--- a/Project1VS/force-app/main/default/aura/party/partyController.js
+++ b/Project1VS/force-app/main/default/aura/party/partyController.js
@@ -1,0 +1,31 @@
+({
+	fillParties : function(component, event, helper) {
+		let parties = component.get("c.getParties");
+        parties.setCallback(this, function(response) {
+            if (response.getState() === 'SUCCESS') {
+                component.set("v.parties", response.getReturnValue());
+            }
+        })
+        $A.enqueueAction(parties);
+	},
+    displayParty : function(cmp, event, helper) {
+        let party = event.getSource().get("v.value");
+        cmp.set("v.currentParty", party);
+        let characters = cmp.get("c.getCharacters");
+        characters.setParam("partyId", party.Id);
+        characters.setCallback(this, function(response) {
+            if (response.getState() === 'SUCCESS') {
+                cmp.set("v.characters", response.getReturnValue());
+            }
+        })
+        $A.enqueueAction(characters);
+        let campaign = cmp.get("c.getCampaign");
+        campaign.setParam("partyId", party.Id);
+        campaign.setCallback(this, function(response) {
+            if (response.getState() === 'SUCCESS') {
+                cmp.set("v.campaign", response.getReturnValue());
+            }
+        })
+        $A.enqueueAction(campaign);
+    }
+})

--- a/Project1VS/force-app/main/default/classes/partyController.cls
+++ b/Project1VS/force-app/main/default/classes/partyController.cls
@@ -1,0 +1,17 @@
+public with sharing class partyController {
+
+    @AuraEnabled
+    public static List<Party__c> getParties() {
+        return [SELECT Id, Name FROM Party__c];
+    }
+    
+    @AuraEnabled
+    public static List<Character__c> getCharacters(Id partyId) {
+        return [SELECT User__r.Name, Name FROM Character__c WHERE Party__c = :partyId];
+    }
+    
+    @AuraEnabled
+    public static DnDCampaign__c getCampaign(Id partyId) {
+        return [SELECT Dungeon_Master__r.Name, Campaign_Name__c FROM DnDCampaign__c WHERE Party__c = :partyId];
+    }
+}

--- a/Project1VS/force-app/main/default/classes/partyController.cls-meta.xml
+++ b/Project1VS/force-app/main/default/classes/partyController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Converted the visual party page into an aura web component. Used slds for styling. Ported over all previous functionality. Added functionality to character names in the party info section. Clicking one now brings the user to the character detail page.